### PR TITLE
Add phoenix rc support

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -32,7 +32,7 @@ defmodule PhoenixSwoosh.Mixfile do
 
   defp deps do
     [{:swoosh, "~> 0.1"},
-     {:phoenix, "~> 1.0"},
+     {:phoenix, "~> 1.0-rc"},
      {:phoenix_html, "~> 2.2"},
      {:credo, "~> 0.6", only: [:dev, :test]},
      {:ex_doc, "~> 0.14", only: :docs},


### PR DESCRIPTION
This commit is going to add support for Phoenix RC versions like Phoenix v1.3.0-rc.2 for example.