### PR TITLE
[Feature] Mimic Phoenix controller interface

### DIFF
--- a/lib/phoenix_swoosh.ex
+++ b/lib/phoenix_swoosh.ex
@@ -33,7 +33,12 @@ defmodule Phoenix.Swoosh do
     end
   end
 
-  defmacro __before_compile__(_env) do
+  defmacro __before_compile__(env) do
+    unless Module.get_attribute(env.module, :view) do
+      raise ArgumentError, "no view was set, " <>
+                           "you can set one with `use Phoenix.Swoosh, view: MyApp.EmailView`"
+    end
+
     quote do
       def render_body(email, template, assigns \\ %{}) do
         email

--- a/lib/phoenix_swoosh.ex
+++ b/lib/phoenix_swoosh.ex
@@ -266,8 +266,7 @@ defmodule Phoenix.Swoosh do
         given
       else
         swoosh_module
-        |> Atom.to_string()
-        |> String.split(".")
+        |> Module.split()
         |> Enum.drop(-1)
         |> Enum.take(2)
         |> Module.concat()

--- a/lib/phoenix_swoosh.ex
+++ b/lib/phoenix_swoosh.ex
@@ -29,6 +29,16 @@ defmodule Phoenix.Swoosh do
         @view Phoenix.Swoosh.__view__(__MODULE__)
       end
 
+      case Keyword.get(opts, :view, nil) do
+        nil -> :ok
+        view -> @view view
+      end
+
+      case Keyword.get(opts, :layout, nil) do
+        nil -> :ok
+        layout -> @layout layout
+      end
+
       @before_compile Phoenix.Swoosh
     end
   end

--- a/test/phoenix_swoosh_test.exs
+++ b/test/phoenix_swoosh_test.exs
@@ -14,7 +14,10 @@ defmodule Phoenix.SwooshTest do
   end
 
   defmodule TestEmail do
-    use Phoenix.Swoosh, view: EmailView
+    use Phoenix.Swoosh
+
+    @view EmailView
+    @layout false
 
     def welcome_html(), do: email() |> render_body("welcome.html", %{})
     def welcome_text(), do: email() |> render_body("welcome.text", %{})
@@ -86,7 +89,10 @@ defmodule Phoenix.SwooshTest do
   end
 
   defmodule TestEmailLayout do
-    use Phoenix.Swoosh, view: EmailView, layout: {LayoutView, :email}
+    use Phoenix.Swoosh
+
+    @view EmailView
+    @layout {LayoutView, :email}
 
     def welcome() do
       %Email{}
@@ -281,14 +287,6 @@ defmodule Phoenix.SwooshTest do
 
     assert %Email{html_body: "<html><h1>Welcome, Avengers!</h1>\n</html>\n"} =
            email
-  end
-
-  test "should raise if no view is set" do
-    assert_raise ArgumentError, fn ->
-      defmodule ErrorEmail do
-        use Phoenix.Swoosh
-      end
-    end
   end
 
   test "body formats are set according to template file extension", %{email: email} do

--- a/test/phoenix_swoosh_test.exs
+++ b/test/phoenix_swoosh_test.exs
@@ -289,6 +289,14 @@ defmodule Phoenix.SwooshTest do
            email
   end
 
+  test "should raise if no view is set" do
+    assert_raise ArgumentError, fn ->
+      defmodule ErrorEmail do
+        use Phoenix.Swoosh, put_default_views: false
+      end
+    end
+  end
+
   test "body formats are set according to template file extension", %{email: email} do
     assert email |> render_body("format_html.html", %{}) |> Map.fetch!(:html_body) =~
              "This is an HTML template"


### PR DESCRIPTION
# Description

Phoenix is a very handy framework with lots of helpers, one of them is the automatic resolution of the module from a `FooController` to a `FooView` when calling the `render` function, I wish `Phoenix.Swoosh` could have the same behaviour, by introducing the same module argument as the `:put_default_views` of `Phoenix.Controller`.

The use of attributes mimics the behaviour of the plug macro inspired by `Nx`'s module configuration using annotations, which also allows us to create a model similar to the rest of `Phoenix` using the root module as a dependency injection.

What do you think ?

# Example

```elixir
defmodule FooWeb do
  def email do
    quote
      use Phoenix.Swoosh
      import SomeOtherHelpers
      alias FooWeb .Router.Helpers, as: Routes
    end
  end

  # ...
end

defmodule FooWeb.BarEmail do
  use FooWeb, :email

  @view FooWeb.CustomBarView
  @layout {FooWeb.LayoutView, :custom_email}

  # ...
end
```