### PR TITLE
Remove transitive compile-time deps in Phoenix.Swoosh macro

### DIFF
--- a/lib/phoenix_swoosh.ex
+++ b/lib/phoenix_swoosh.ex
@@ -29,6 +29,8 @@ defmodule Phoenix.Swoosh do
             """
     end
 
+    view_module = if template_root, do: quote(do: __MODULE__), else: view
+
     quote do
       import Swoosh.Email
       import Phoenix.Swoosh, except: [render_body: 3]
@@ -43,7 +45,7 @@ defmodule Phoenix.Swoosh do
       def render_body(email, template, assigns \\ %{}) do
         email
         |> put_new_layout(unquote(layout))
-        |> put_new_view(if(unquote(template_root), do: __MODULE__, else: unquote(view)))
+        |> put_new_view(unquote(view_module))
         |> Phoenix.Swoosh.render_body(template, assigns)
       end
     end


### PR DESCRIPTION
The `view` and `layout` options are creating dependencies at compile time because they use module attributes and the bind_quoted option in the macro. This change injects the values into the `render_body` function without creating dependencies.

I have tested it on an empty project with the example of the README, elixir 1.13 and phoenix 1.6. Now `mix xref` does not return files that lead to transitive compile-time deps, before the change it returned the following:
```
$ mix xref graph --label compile-connected
lib/hello/user_notifier.ex
└── lib/hello_web/views/user_notifier_view.ex (compile)
```