### PR TITLE
Add custom extension mapping

### DIFF
--- a/test/fixtures/templates/email/format_html.custom.eex
+++ b/test/fixtures/templates/email/format_html.custom.eex
@@ -1,0 +1,1 @@
+This is an HTML template with the .custom extension.

--- a/test/fixtures/templates/email/welcome.custom.eex
+++ b/test/fixtures/templates/email/welcome.custom.eex
@@ -1,0 +1,1 @@
+<element>Welcome, Avengers!</element>

--- a/test/fixtures/templates/email/welcome_assigns.custom.eex
+++ b/test/fixtures/templates/email/welcome_assigns.custom.eex
@@ -1,0 +1,1 @@
+<element>Welcome, <%= @name %>!</element>

--- a/test/fixtures/templates/layout/email.custom.eex
+++ b/test/fixtures/templates/layout/email.custom.eex
@@ -1,0 +1,1 @@
+<layout><%= @inner_content %></layout>

--- a/test/fixtures/templates/test_view_included_notifier_formats/welcome_assigns.custom.eex
+++ b/test/fixtures/templates/test_view_included_notifier_formats/welcome_assigns.custom.eex
@@ -1,0 +1,1 @@
+<element>Welcome, <%= @name %>!</element>

--- a/test/fixtures/templates/test_view_included_notifier_formats/welcome_assigns.text.eex
+++ b/test/fixtures/templates/test_view_included_notifier_formats/welcome_assigns.text.eex
@@ -1,0 +1,1 @@
+Welcome, <%= @name %>!

--- a/test/phoenix_swoosh_test.exs
+++ b/test/phoenix_swoosh_test.exs
@@ -19,32 +19,14 @@ defmodule Phoenix.SwooshTest do
     def welcome_html(), do: email() |> render_body("welcome.html", %{})
     def welcome_text(), do: email() |> render_body("welcome.text", %{})
 
-    def welcome_custom() do
-      email()
-      |> put_formats(%{"html" => "custom"})
-      |> render_body("welcome.custom", %{})
-    end
-
     def welcome_html_assigns(),
       do: email() |> render_body("welcome_assigns.html", %{name: "Tony"})
 
     def welcome_text_assigns(),
       do: email() |> render_body("welcome_assigns.text", %{name: "Tony"})
 
-    def welcome_custom_assigns() do
-      email()
-      |> put_formats(%{"html" => "custom"})
-      |> render_body("welcome_assigns.custom", %{name: "Tony"})
-    end
-
     def welcome_html_without_assigns(), do: email() |> render_body("welcome.html")
     def welcome_text_without_assigns(), do: email() |> render_body("welcome.text")
-
-    def welcome_custom_without_assigns() do
-      email()
-      |> put_formats(%{"html" => "custom"})
-      |> render_body("welcome.custom")
-    end
 
     def welcome_html_layout() do
       email()
@@ -98,32 +80,6 @@ defmodule Phoenix.SwooshTest do
       |> render_body(:welcome_assigns, %{name: "Tony"})
     end
 
-    def welcome_formats() do
-      email()
-      |> put_formats(%{"html" => "custom", "text" => "text"})
-      |> render_body(:welcome, %{})
-    end
-
-    def welcome_formats_assigns() do
-      email()
-      |> put_formats(%{"html" => "custom", "text" => "text"})
-      |> render_body(:welcome_assigns, %{name: "Tony"})
-    end
-
-    def welcome_formats_layout() do
-      email()
-      |> put_formats(%{"html" => "custom", "text" => "text"})
-      |> put_layout({LayoutView, :email})
-      |> render_body(:welcome, %{})
-    end
-
-    def welcome_formats_layout_assigns() do
-      email()
-      |> put_formats(%{"html" => "custom", "text" => "text"})
-      |> put_layout({LayoutView, :email})
-      |> render_body(:welcome_assigns, %{name: "Tony"})
-    end
-
     def email() do
       %Email{}
       |> from("tony@stark.com")
@@ -146,7 +102,7 @@ defmodule Phoenix.SwooshTest do
 
   defmodule TestEmailLayoutFormats do
     use Phoenix.Swoosh,
-      formats: %{"html" => "custom", "text" => "text"},
+      formats: %{"custom" => :html_body, "text" => :text_body},
       view: EmailView,
       layout: {LayoutView, :email}
 
@@ -186,7 +142,7 @@ defmodule Phoenix.SwooshTest do
 
   defmodule TestViewIncludedNotifierFormats do
     use Phoenix.Swoosh,
-      formats: %{"html" => "custom", "text" => "text"},
+      formats: %{"custom" => :html_body, "text" => :text_body},
       template_root: "test/fixtures/templates",
       template_namespace: Phoenix.SwooshTest
 
@@ -304,11 +260,6 @@ defmodule Phoenix.SwooshTest do
     assert %Email{text_body: "Welcome, Avengers!\n"} = TestEmail.welcome_text()
   end
 
-  test "macro: render html body with custom format" do
-    assert %Email{html_body: "<element>Welcome, Avengers!</element>\n"} =
-             TestEmail.welcome_custom()
-  end
-
   test "macro: render html body with layout" do
     assert %Email{html_body: "<html><h1>Welcome, Avengers!</h1>\n</html>\n"} =
              TestEmail.welcome_html_layout()
@@ -337,22 +288,12 @@ defmodule Phoenix.SwooshTest do
     assert %Email{text_body: "Welcome, Avengers!\n"} = TestEmail.welcome_text_without_assigns()
   end
 
-  test "macro: render html body with custom format and without assigns" do
-    assert %Email{html_body: "<element>Welcome, Avengers!</element>\n"} =
-             TestEmail.welcome_custom_without_assigns()
-  end
-
   test "macro: render html body with assigns" do
     assert %Email{html_body: "<h1>Welcome, Tony!</h1>\n"} = TestEmail.welcome_html_assigns()
   end
 
   test "macro: render text body with assigns" do
     assert %Email{text_body: "Welcome, Tony!\n"} = TestEmail.welcome_text_assigns()
-  end
-
-  test "macro: render html body with custom format and assigns" do
-    assert %Email{html_body: "<element>Welcome, Tony!</element>\n"} =
-             TestEmail.welcome_custom_assigns()
   end
 
   test "macro: render html body with layout and assigns" do
@@ -386,34 +327,6 @@ defmodule Phoenix.SwooshTest do
              html_body: "<html><h1>Welcome, Tony!</h1>\n</html>\n",
              text_body: "TEXT: Welcome, Tony!\n\n"
            } = TestEmail.welcome_layout_assigns()
-  end
-
-  test "macro: render both html and text body with custom formats" do
-    assert %Email{
-             html_body: "<element>Welcome, Avengers!</element>\n",
-             text_body: "Welcome, Avengers!\n"
-           } = TestEmail.welcome_formats()
-  end
-
-  test "macro: render both html and text body with custom formats and assigns" do
-    assert %Email{
-             html_body: "<element>Welcome, Tony!</element>\n",
-             text_body: "Welcome, Tony!\n"
-           } = TestEmail.welcome_formats_assigns()
-  end
-
-  test "macro: render both html and text body with custom formats and layout" do
-    assert %Email{
-             html_body: "<layout><element>Welcome, Avengers!</element>\n</layout>\n",
-             text_body: "TEXT: Welcome, Avengers!\n\n"
-           } = TestEmail.welcome_formats_layout()
-  end
-
-  test "macro: render both html and text body with custom formats, layout, and assigns" do
-    assert %Email{
-             html_body: "<layout><element>Welcome, Tony!</element>\n</layout>\n",
-             text_body: "TEXT: Welcome, Tony!\n\n"
-           } = TestEmail.welcome_formats_layout_assigns()
   end
 
   test "macro: use layout when provided via `use` macro " do
@@ -501,11 +414,5 @@ defmodule Phoenix.SwooshTest do
 
     assert email |> render_body("format_text.unknown", %{}) |> Map.fetch!(:text_body) =~
              "This is a text template"
-
-    assert email
-           |> put_formats(%{"html" => "custom", "text" => "text"})
-           |> render_body("format_html.custom", %{})
-           |> Map.fetch!(:html_body) =~
-             "This is an HTML template"
   end
 end

--- a/test/phoenix_swoosh_test.exs
+++ b/test/phoenix_swoosh_test.exs
@@ -19,14 +19,32 @@ defmodule Phoenix.SwooshTest do
     def welcome_html(), do: email() |> render_body("welcome.html", %{})
     def welcome_text(), do: email() |> render_body("welcome.text", %{})
 
+    def welcome_custom() do
+      email()
+      |> put_formats(%{"html" => "custom"})
+      |> render_body("welcome.custom", %{})
+    end
+
     def welcome_html_assigns(),
       do: email() |> render_body("welcome_assigns.html", %{name: "Tony"})
 
     def welcome_text_assigns(),
       do: email() |> render_body("welcome_assigns.text", %{name: "Tony"})
 
+    def welcome_custom_assigns() do
+      email()
+      |> put_formats(%{"html" => "custom"})
+      |> render_body("welcome_assigns.custom", %{name: "Tony"})
+    end
+
     def welcome_html_without_assigns(), do: email() |> render_body("welcome.html")
     def welcome_text_without_assigns(), do: email() |> render_body("welcome.text")
+
+    def welcome_custom_without_assigns() do
+      email()
+      |> put_formats(%{"html" => "custom"})
+      |> render_body("welcome.custom")
+    end
 
     def welcome_html_layout() do
       email()
@@ -80,6 +98,32 @@ defmodule Phoenix.SwooshTest do
       |> render_body(:welcome_assigns, %{name: "Tony"})
     end
 
+    def welcome_formats() do
+      email()
+      |> put_formats(%{"html" => "custom", "text" => "text"})
+      |> render_body(:welcome, %{})
+    end
+
+    def welcome_formats_assigns() do
+      email()
+      |> put_formats(%{"html" => "custom", "text" => "text"})
+      |> render_body(:welcome_assigns, %{name: "Tony"})
+    end
+
+    def welcome_formats_layout() do
+      email()
+      |> put_formats(%{"html" => "custom", "text" => "text"})
+      |> put_layout({LayoutView, :email})
+      |> render_body(:welcome, %{})
+    end
+
+    def welcome_formats_layout_assigns() do
+      email()
+      |> put_formats(%{"html" => "custom", "text" => "text"})
+      |> put_layout({LayoutView, :email})
+      |> render_body(:welcome_assigns, %{name: "Tony"})
+    end
+
     def email() do
       %Email{}
       |> from("tony@stark.com")
@@ -100,8 +144,49 @@ defmodule Phoenix.SwooshTest do
     end
   end
 
+  defmodule TestEmailLayoutFormats do
+    use Phoenix.Swoosh,
+      formats: %{"html" => "custom", "text" => "text"},
+      view: EmailView,
+      layout: {LayoutView, :email}
+
+    def welcome() do
+      %Email{}
+      |> from("tony@stark.com")
+      |> to("steve@rogers.com")
+      |> subject("Welcome, Avengers!")
+      |> render_body(:welcome, %{})
+    end
+  end
+
   defmodule TestViewIncludedNotifier do
     use Phoenix.Swoosh,
+      template_root: "test/fixtures/templates",
+      template_namespace: Phoenix.SwooshTest
+
+    import Swoosh.Email
+
+    def welcome_assigns do
+      %Email{}
+      |> from("tony@stark.com")
+      |> to("steve@rogers.com")
+      |> subject("Welcome, Avengers!")
+      |> render_body(:welcome_assigns, %{name: "Tony"})
+    end
+
+    def welcome_layout do
+      %Email{}
+      |> from("tony@stark.com")
+      |> to("steve@rogers.com")
+      |> subject("Welcome, Avengers!")
+      |> put_layout({LayoutView, :email})
+      |> render_body(:welcome_assigns, %{name: "Avengers"})
+    end
+  end
+
+  defmodule TestViewIncludedNotifierFormats do
+    use Phoenix.Swoosh,
+      formats: %{"html" => "custom", "text" => "text"},
       template_root: "test/fixtures/templates",
       template_namespace: Phoenix.SwooshTest
 
@@ -219,6 +304,11 @@ defmodule Phoenix.SwooshTest do
     assert %Email{text_body: "Welcome, Avengers!\n"} = TestEmail.welcome_text()
   end
 
+  test "macro: render html body with custom format" do
+    assert %Email{html_body: "<element>Welcome, Avengers!</element>\n"} =
+             TestEmail.welcome_custom()
+  end
+
   test "macro: render html body with layout" do
     assert %Email{html_body: "<html><h1>Welcome, Avengers!</h1>\n</html>\n"} =
              TestEmail.welcome_html_layout()
@@ -247,12 +337,22 @@ defmodule Phoenix.SwooshTest do
     assert %Email{text_body: "Welcome, Avengers!\n"} = TestEmail.welcome_text_without_assigns()
   end
 
+  test "macro: render html body with custom format and without assigns" do
+    assert %Email{html_body: "<element>Welcome, Avengers!</element>\n"} =
+             TestEmail.welcome_custom_without_assigns()
+  end
+
   test "macro: render html body with assigns" do
     assert %Email{html_body: "<h1>Welcome, Tony!</h1>\n"} = TestEmail.welcome_html_assigns()
   end
 
   test "macro: render text body with assigns" do
     assert %Email{text_body: "Welcome, Tony!\n"} = TestEmail.welcome_text_assigns()
+  end
+
+  test "macro: render html body with custom format and assigns" do
+    assert %Email{html_body: "<element>Welcome, Tony!</element>\n"} =
+             TestEmail.welcome_custom_assigns()
   end
 
   test "macro: render html body with layout and assigns" do
@@ -288,11 +388,46 @@ defmodule Phoenix.SwooshTest do
            } = TestEmail.welcome_layout_assigns()
   end
 
+  test "macro: render both html and text body with custom formats" do
+    assert %Email{
+             html_body: "<element>Welcome, Avengers!</element>\n",
+             text_body: "Welcome, Avengers!\n"
+           } = TestEmail.welcome_formats()
+  end
+
+  test "macro: render both html and text body with custom formats and assigns" do
+    assert %Email{
+             html_body: "<element>Welcome, Tony!</element>\n",
+             text_body: "Welcome, Tony!\n"
+           } = TestEmail.welcome_formats_assigns()
+  end
+
+  test "macro: render both html and text body with custom formats and layout" do
+    assert %Email{
+             html_body: "<layout><element>Welcome, Avengers!</element>\n</layout>\n",
+             text_body: "TEXT: Welcome, Avengers!\n\n"
+           } = TestEmail.welcome_formats_layout()
+  end
+
+  test "macro: render both html and text body with custom formats, layout, and assigns" do
+    assert %Email{
+             html_body: "<layout><element>Welcome, Tony!</element>\n</layout>\n",
+             text_body: "TEXT: Welcome, Tony!\n\n"
+           } = TestEmail.welcome_formats_layout_assigns()
+  end
+
   test "macro: use layout when provided via `use` macro " do
     assert %Email{
              html_body: "<html><h1>Welcome, Avengers!</h1>\n</html>\n",
              text_body: "TEXT: Welcome, Avengers!\n\n"
            } = TestEmailLayout.welcome()
+  end
+
+  test "macro: use layout for custom format when provided via `use` macro " do
+    assert %Email{
+             html_body: "<layout><element>Welcome, Avengers!</element>\n</layout>\n",
+             text_body: "TEXT: Welcome, Avengers!\n\n"
+           } = TestEmailLayoutFormats.welcome()
   end
 
   test "email is available in template", %{email: email} do
@@ -324,6 +459,22 @@ defmodule Phoenix.SwooshTest do
     end
   end
 
+  describe "view included and formats defined" do
+    test "render both html and text body with assigns" do
+      assert %Email{
+               html_body: "<element>Welcome, Tony!</element>\n",
+               text_body: "Welcome, Tony!\n"
+             } = TestViewIncludedNotifierFormats.welcome_assigns()
+    end
+
+    test "render both html and text body with layout" do
+      assert %Email{
+               html_body: "<layout><element>Welcome, Avengers!</element>\n</layout>\n",
+               text_body: "TEXT: Welcome, Avengers!\n\n"
+             } = TestViewIncludedNotifierFormats.welcome_layout()
+    end
+  end
+
   test "should raise if no view is set" do
     assert_raise ArgumentError, fn ->
       defmodule ErrorEmail do
@@ -350,5 +501,11 @@ defmodule Phoenix.SwooshTest do
 
     assert email |> render_body("format_text.unknown", %{}) |> Map.fetch!(:text_body) =~
              "This is a text template"
+
+    assert email
+           |> put_formats(%{"html" => "custom", "text" => "text"})
+           |> render_body("format_html.custom", %{})
+           |> Map.fetch!(:html_body) =~
+             "This is an HTML template"
   end
 end

--- a/test/phoenix_swoosh_test.exs
+++ b/test/phoenix_swoosh_test.exs
@@ -106,7 +106,7 @@ defmodule Phoenix.SwooshTest do
       view: EmailView,
       layout: {LayoutView, :email}
 
-    def welcome() do
+    def welcome do
       %Email{}
       |> from("tony@stark.com")
       |> to("steve@rogers.com")
@@ -329,14 +329,14 @@ defmodule Phoenix.SwooshTest do
            } = TestEmail.welcome_layout_assigns()
   end
 
-  test "macro: use layout when provided via `use` macro " do
+  test "macro: use layout when provided via `use` macro" do
     assert %Email{
              html_body: "<html><h1>Welcome, Avengers!</h1>\n</html>\n",
              text_body: "TEXT: Welcome, Avengers!\n\n"
            } = TestEmailLayout.welcome()
   end
 
-  test "macro: use layout for custom format when provided via `use` macro " do
+  test "macro: use layout for custom format when provided via `use` macro" do
     assert %Email{
              html_body: "<layout><element>Welcome, Avengers!</element>\n</layout>\n",
              text_body: "TEXT: Welcome, Avengers!\n\n"
@@ -398,21 +398,21 @@ defmodule Phoenix.SwooshTest do
 
   test "body formats are set according to template file extension", %{email: email} do
     assert email |> render_body("format_html.html", %{}) |> Map.fetch!(:html_body) =~
-             "This is an HTML template"
+             "HTML template with the .html extension"
 
     assert email |> render_body("format_html.htm", %{}) |> Map.fetch!(:html_body) =~
-             "This is an HTML template"
+             "HTML template with the .htm extension"
 
     assert email |> render_body("format_html.xml", %{}) |> Map.fetch!(:html_body) =~
-             "This is an HTML template"
+             "HTML template with the .xml extension"
 
     assert email |> render_body("format_text.txt", %{}) |> Map.fetch!(:text_body) =~
-             "This is a text template"
+             "text template with the .txt extension"
 
     assert email |> render_body("format_text.text", %{}) |> Map.fetch!(:text_body) =~
-             "This is a text template"
+             "text template with the .text extension"
 
     assert email |> render_body("format_text.unknown", %{}) |> Map.fetch!(:text_body) =~
-             "This is a text template"
+             "text template with an unknown extension"
   end
 end


### PR DESCRIPTION
Thanks for the great library!

This PR is probably a bit odd, so I understand if you're not interested in accepting it.

Basically, I was wanting to use MJML for HTML email templates, and I couldn't figure out an elegant way to make it work and ended up with this.

It allows formats to be customized so that for other template extensions can be used. For instance, to make MJML work:

```elixir
defmodule Notifier do
  use Phoenix.Swoosh, formats: %{"html" => "mjml", "text" => "text"}
end

config :phoenix, format_encoders: [mjml: Phoenix.Mjml]

defmodule Phoenix.Mjml do
  def encode_to_iodata!(mjml) do
    with {:ok, html} <- Mjml.to_html(mjml) do
      html
    end
  end
end
```

If you're interested but want some changes, let me know. Thanks!